### PR TITLE
removed buggy Youtube link

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,10 +139,6 @@
 
           <h5>Data is provided by <a href="https://data.seattle.gov/" target="_blank">data.seattle.gov</a> and is found <a href="https://data.seattle.gov/Community/Parks-and-Park-Features/rhf2-u5fm" target="_blank">here</a></h5>
           <h6>*Seattle Park Finder is not responsible for misinformation</h6>
-
-          <iframe width="520" height="305"
-            src="https://www.youtube.com/v/uIDui9D1LVA">
-          </iframe>
         </section>
       </main>
     </div>


### PR DESCRIPTION
I pulled the Youtube video in the About section because Brook was having an issue with it downloading a file onto his system. If we really want to add this back we can look into the issue and re-link the video.
